### PR TITLE
更新nonebot-plugin-alconna和pydantic版本要求

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,9 @@ classifiers = [
 python = "^3.8"
 nonebot2 = "^2.0.0"
 nonebot-adapter-onebot = "^2.2.0"
-nonebot-plugin-alconna = "^0.30.0"
+nonebot-plugin-alconna = ">=0.30.0"
+pydantic = ">=1.9.0"
 aiohttp = "^3.7.4"
-pydantic = "^1.9.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.0.0"
@@ -70,3 +70,4 @@ python_files = ["test_*.py", "*_test.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 asyncio_mode = "auto"
+


### PR DESCRIPTION
因nonebot-plugin-alconna和pydantic版本要求太低，导致与其他插件的兼容性极差，无法正常运行。
所以将版本要求放宽松，已测试正常运行。
依赖性更新：    
* 将' noebot-plugin-alconna '的版本限制从精确版本（"0.30.0"）更改为最低版本（'>=0.30.0 '），以允许更新的兼容版本。 
* 将“pydantic”的版本约束从精确版本（“1.9.0”）更改为最低版本（“>=1.9.0”），以允许更新的兼容版本。